### PR TITLE
Adding Enabled Field and Remove Schedule Config

### DIFF
--- a/googleCalendar/km/connector/googleCalendar_connector.json
+++ b/googleCalendar/km/connector/googleCalendar_connector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "122501",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -257,9 +258,5 @@
         }
       ]
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }


### PR DESCRIPTION
Schedule Configurations will soon be removed from all push connectors
with added validation preventing it. Adding enabled flag which will
be used when pushing data - the enabled flag uses the boolean from
use source schedule
